### PR TITLE
adminset二次修改

### DIFF
--- a/cmdb/models.py
+++ b/cmdb/models.py
@@ -51,8 +51,8 @@ class Idc(models.Model):
 
 
 class Host(models.Model):
-    hostname = models.CharField(max_length=50, verbose_name=u"主机名", unique=True)
-    ip = models.GenericIPAddressField(u"管理IP", max_length=15)
+    hostname = models.CharField(max_length=50, verbose_name=u"主机名")
+    ip = models.GenericIPAddressField(u"管理IP", max_length=15, unique=True)
     idc = models.ForeignKey(Idc, verbose_name=u"所在机房", on_delete=models.SET_NULL, null=True, blank=True)
     other_ip = models.CharField(u"其它IP", max_length=100, blank=True)
     asset_no = models.CharField(u"资产编号", max_length=50, blank=True)

--- a/install/client/adminset_agent.py
+++ b/install/client/adminset_agent.py
@@ -23,10 +23,17 @@ log("agent.log", "/var/opt/adminset/client/")
 def get_ip():
     try:
         hostname = socket.getfqdn(socket.gethostname())
-        ipaddr = socket.gethostbyname(hostname)
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(('223.5.5.5', 80))
+        ipaddr = s.getsockname()[0]
+
     except Exception as msg:
         print(msg)
         ipaddr = ''
+
+    finally:
+        s.close()
+
     return ipaddr
 
 

--- a/install/server/auto_install.sh
+++ b/install/server/auto_install.sh
@@ -67,7 +67,7 @@ systemctl enable webssh.service
 echo "####install database####"
 echo "installing a new mariadb...."
 yum install -y mariadb-server mariadb-devel
-service mariadb start
+systemctl mariadb start
 chkconfig mariadb on
 mysql -e "CREATE DATABASE if not exists adminset DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;"
 
@@ -109,13 +109,13 @@ source /etc/profile
 scp $adminset_dir/install/server/adminset.service /usr/lib/systemd/system
 systemctl daemon-reload
 chkconfig adminset on
-service adminset start
+systemctl adminset start
 
 #安装redis
 echo "####install redis####"
 yum install redis -y
 chkconfig redis on
-service redis start
+systemctl redis start
 
 # 安装celery
 echo "####install celery####"
@@ -128,8 +128,8 @@ chmod +x $config_dir/celery/start_celery.sh
 systemctl daemon-reload
 chkconfig celery on
 chkconfig beat on
-service celery start
-service beat start
+systemctl celery start
+systemctl beat start
 
 # 安装nginx
 echo "####install nginx####"
@@ -137,7 +137,7 @@ yum install nginx -y
 chkconfig nginx on
 scp $adminset_dir/install/server/nginx/adminset.conf /etc/nginx/conf.d
 scp $adminset_dir/install/server/nginx/nginx.conf /etc/nginx
-service nginx start
+systemctl nginx start
 nginx -s reload
 
 # create ssh config
@@ -154,14 +154,14 @@ scp $adminset_dir/install/server/ssh/config ~/.ssh/config
 # 完成安装
 echo "##############install finished###################"
 systemctl daemon-reload
-service redis restart
-service mariadb restart
-service adminset restart
-service celery restart
-service beat restart
-service mongod restart
-service sshd restart
-service webssh restart
+systemctl redis restart
+systemctl mariadb restart
+systemctl adminset restart
+systemctl celery restart
+systemctl beat restart
+systemctl mongod restart
+systemctl sshd restart
+systemctl webssh restart
 echo "please access website http://server_ip"
 echo "you have installed adminset successfully!!!"
 echo "################################################"

--- a/templates/config/index.html
+++ b/templates/config/index.html
@@ -142,7 +142,7 @@
                   </div>
                 </div>
                 <hr>
-                    <p><b>Reids</b></p>
+                    <p><b>Redis</b></p>
                 <div class="form-group">
                   <label for="_host" class="col-sm-2 control-label">Host:</label>
                   <div class="col-sm-10">


### PR DESCRIPTION
1.修复配置页面文案错误：Reids-->Redis;
2.修复部分客户端只能获取127.0.0.1问题；
3.解除强依赖主机名，修改为依赖IP；
4.修改服务端在centos7下自动部署启动方式，将service修改为systemctl。